### PR TITLE
Use new prompts property

### DIFF
--- a/studio/dashboard.cp.js
+++ b/studio/dashboard.cp.js
@@ -514,7 +514,7 @@ export class Dashboard extends DashboardCommon {
 
   async confirm (ask) {
     const confirmDialog = this.openDialog(GalyleoConfirmPrompt);
-    confirmDialog.label = ask;
+    confirmDialog.title = ask;
     return await confirmDialog.activate();
   }
 


### PR DESCRIPTION
We recently included the option to specify `title` and `text` for prompts separately. Therefore, the `label` property does not exist anymore. Cautious: Merging this requires a version of lively.next newer than f4a7f8ee30f92ff033c839779cc13fc9bdfab6bb!